### PR TITLE
feat: add an equivalent of WaitWrapper for os.Process

### DIFF
--- a/pkg/cmd/proc/reaper/wait.go
+++ b/pkg/cmd/proc/reaper/wait.go
@@ -6,6 +6,7 @@ package reaper
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -30,6 +31,36 @@ func WaitWrapper(usingReaper bool, notifyCh <-chan ProcessInfo, cmd *exec.Cmd) e
 
 	// still do cmd.Wait() to release any resources
 	waitErr := cmd.Wait()
+	if err == nil && waitErr != nil && waitErr.Error() != "waitid: no child processes" {
+		err = waitErr
+	}
+
+	return err
+}
+
+// ProcessWaitWrapper emulates os/exec.Process.Wait() when reaper is running.
+// It is equivalent to WaitWrapper
+//
+// ProcessWaitWrapper(true, proc) should be equivalent to proc.Wait().
+func ProcessWaitWrapper(usingReaper bool, notifyCh <-chan ProcessInfo, proc *os.Process) error {
+	if !usingReaper {
+		_, waitErr := proc.Wait()
+
+		return waitErr
+	}
+
+	var info ProcessInfo
+
+	for info = range notifyCh {
+		if info.Pid == proc.Pid && (info.Status.Exited() || info.Status.Signaled()) {
+			break
+		}
+	}
+
+	err := convertWaitStatus(info.Status)
+
+	// release any resources
+	waitErr := proc.Release()
 	if err == nil && waitErr != nil && waitErr.Error() != "waitid: no child processes" {
 		err = waitErr
 	}


### PR DESCRIPTION
For using os.Process in Talos replacing exec.Cmd in some places we need to ba able to use reaper with it.

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
