### PR TITLE
fix: ProcessWaitWrapper: return an error on nonzero exit code

### DIFF
--- a/pkg/cmd/proc/reaper/wait.go
+++ b/pkg/cmd/proc/reaper/wait.go
@@ -44,9 +44,16 @@ func WaitWrapper(usingReaper bool, notifyCh <-chan ProcessInfo, cmd *exec.Cmd) e
 // ProcessWaitWrapper(true, proc) should be equivalent to proc.Wait().
 func ProcessWaitWrapper(usingReaper bool, notifyCh <-chan ProcessInfo, proc *os.Process) error {
 	if !usingReaper {
-		_, waitErr := proc.Wait()
+		state, err := proc.Wait()
+		if err != nil {
+			return err
+		}
 
-		return waitErr
+		if !state.Success() {
+			return &exec.ExitError{ProcessState: state}
+		}
+
+		return nil
 	}
 
 	var info ProcessInfo


### PR DESCRIPTION
This is how cmd.Wait does and what Talos needs for tests not to fail

Should we make version 1.2.1 or 1.3 for this?

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
